### PR TITLE
Feature/add babel polyfill for ie section

### DIFF
--- a/tutorial/003.md
+++ b/tutorial/003.md
@@ -64,7 +64,7 @@ add_action( 'wp_enqueue_scripts', function() {
 
 Internet Explorer 11 で Embed API を利用するには `@babel/polyfill` の適用が必要です。Embed API を読み込む前に CDN などから読み込むようにしてください。以下は [cdnjs.com](https://cdnjs.com/libraries/babel-polyfill) から `@babel/polyfill` を読み込む例です。
 
-```HTML
+```html
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.3/polyfill.min.js"></script>
 <script type="text/javascript" src="https://api.tilecloud.io/v1/embed?tilecloud-api-key=YOUR-API-KEY"></script>
 ```

--- a/tutorial/003.md
+++ b/tutorial/003.md
@@ -59,3 +59,12 @@ add_action( 'wp_enqueue_scripts', function() {
   );
 } );
 ```
+
+## Internet Explorer 11 で Embed API を利用する
+
+Internet Explorer 11 で Embed API を利用するには `@babel/polyfill` の適用が必要です。Embed API を読み込む前に CDN などから読み込むようにしてください。以下は [cdnjs.com](https://cdnjs.com/libraries/babel-polyfill) から `@babel/polyfill` を読み込む例です。
+
+```HTML
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.3/polyfill.min.js"></script>
+<script type="text/javascript" src="https://api.tilecloud.io/v1/embed?tilecloud-api-key=YOUR-API-KEY"></script>
+```


### PR DESCRIPTION
This PR follows https://github.com/tilecloud/embed/pull/44, for the case which the users desire to use ie11 and they have to use `@babel/polyfill`.